### PR TITLE
Refactor markSpans to operate on full body

### DIFF
--- a/templates/pages/andersen-single.html
+++ b/templates/pages/andersen-single.html
@@ -130,7 +130,7 @@
           };
 
             function markSpans(span) {
-                const content = span.querySelector('#content');
+                const content = span.ownerDocument.body;
                 const walker = document.createTreeWalker(
                 content,
                 NodeFilter.SHOW_ALL | NodeFilter.SHOW_TEXT
@@ -186,9 +186,9 @@
                     const root = ev.detail.root.querySelector('#body');
                     extractTemplates(root, ev.detail.root, 1);
                     addButtons(ev.detail.root.querySelectorAll(`.container`));
-                    markSpans(ev.detail.root);
-            }, false);         
-        });   
+                    markSpans(document.body);
+            }, false);
+        });
      </script>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- Ensure `markSpans` walks the entire document body by using `span.ownerDocument.body`
- Invoke `markSpans` with `document.body` so spans across the whole page are processed

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c3c4e6bc908329b05678d3b072cf00