### PR TITLE
Add collate page template

### DIFF
--- a/templates/pages/collate.html
+++ b/templates/pages/collate.html
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <meta name="viewport"
+          content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes"/>
+    <link rel="shortcut icon" type="image/x-icon" href="resources/images/favicon.ico"/>
+    <link rel="shortcut icon" type="image/png" href="resources/images/favicon-16.png" sizes="16x16"/>
+    <link rel="shortcut icon" type="image/png" href="resources/images/favicon-24.png" sizes="24x24"/>
+    <link rel="shortcut icon" type="image/png" href="resources/images/favicon-32.png" sizes="32x32"/>
+    <link rel="shortcut icon" type="image/png" href="resources/images/favicon-64.png" sizes="64x64"/>
+
+    <title data-template="config:app-title"/>
+    <meta name="description" content="Collation table view"/>
+    <meta name="pb-template" content="collate.html"/>
+
+    <link rel="stylesheet" type="text/css" href="resources/fonts/font.css"/>
+    <link rel="stylesheet"
+          href="https://fonts.googleapis.com/css?family=Oswald&amp;display=swap"/>
+    <link rel="stylesheet" href="resources/css/theme.css"/>
+    <!-- optional: add your own collation-specific stylesheet -->
+    <!-- <link rel="stylesheet" href="resources/css/collate.css"/> -->
+
+    <script type="module"
+            src="pb-components-bundle.js"
+            data-template="pages:load-components"></script>
+  </head>
+
+  <body>
+    <pb-page data-template="pages:pb-page" unresolved="unresolved">
+      <pb-document id="document1" data-template="pages:pb-document"/>
+      <app-drawer-layout force-narrow="force-narrow">
+        <app-drawer data-template="templates:include"
+                    data-template-path="templates/drawer.html"/>
+        <app-header-layout>
+          <app-header slot="header" reveals fixed effects="waterfall">
+            <app-toolbar data-template="templates:include"
+                         data-template-path="templates/menu.html"/>
+            <app-toolbar data-template="templates:include"
+                         data-template-path="templates/toolbar.html"/>
+          </app-header>
+
+          <pb-drawer toggle="tocToggle" class="toc"
+                     emit="toc" subscribe="transcription">
+            <div class="drawer-content">
+              <h3><pb-i18n key="document.contents">Contents</pb-i18n></h3>
+              <pb-load id="toc"
+                       url="api/document/{doc}/contents?target=collation&amp;icons=true"
+                       expand="expand" src="document1"
+                       subscribe="toc" load-once="load-once">
+                <pb-i18n key="dialogs.loading">Loading</pb-i18n>
+              </pb-load>
+            </div>
+          </pb-drawer>
+
+          <section class="breadcrumbs">
+            <pb-view id="title-view1" src="document1"
+                     xpath="//teiHeader/fileDesc/titleStmt/title" view="single">
+              <pb-param name="header" value="short"/>
+            </pb-view>
+          </section>
+
+          <main class="content-body">
+            <!-- Collation table component -->
+            <pb-collation-table id="collation"
+                                src="document1"
+                                witnesses="A,B,C"
+                                show-headers="show-headers"
+                                subscribe="transcription"
+                                emit="transcription">
+            </pb-collation-table>
+          </main>
+        </app-header-layout>
+      </app-drawer-layout>
+    </pb-page>
+    <div class="splash"></div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add `collate.html` template to render collation tables via pb-collation-table component

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c7f3fad6108329af9f52a5e5e2d20d